### PR TITLE
default margins are too large for monitor displays

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2,6 +2,7 @@ h1 {
 	color: white;
 	font-family: Helvetica, sans-serif;
 	text-align: center;
+	margin: 5px 0;
 }
 
 h2 {


### PR DESCRIPTION
On chrome the default is 27px ... way too large
